### PR TITLE
[FEAT] 태양광 패널 API

### DIFF
--- a/xolar/src/main/java/com/xodid/xolar/bill/domain/Bill.java
+++ b/xolar/src/main/java/com/xodid/xolar/bill/domain/Bill.java
@@ -1,16 +1,19 @@
 package com.xodid.xolar.bill.domain;
 
+import com.xodid.xolar.global.BaseTimeEntity;
 import com.xodid.xolar.solarpanel.domain.SolarPanel;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
+@Getter
 @DynamicInsert // insert시 지정된 default값 적용
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Bill {
+public class Bill extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="bill_id",updatable = false)

--- a/xolar/src/main/java/com/xodid/xolar/bill/repository/BillRepository.java
+++ b/xolar/src/main/java/com/xodid/xolar/bill/repository/BillRepository.java
@@ -1,0 +1,13 @@
+package com.xodid.xolar.bill.repository;
+
+import com.xodid.xolar.bill.domain.Bill;
+import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BillRepository extends JpaRepository<Bill, Long> {
+    List<Bill> findAllBySolarPanel(SolarPanel solarPanel);
+}

--- a/xolar/src/main/java/com/xodid/xolar/bill/repository/BillRepository.java
+++ b/xolar/src/main/java/com/xodid/xolar/bill/repository/BillRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 
 @Repository
 public interface BillRepository extends JpaRepository<Bill, Long> {
+    // 특정 SolarPanel과 연관된 Bill 엔티티 리스트 반환
     List<Bill> findAllBySolarPanel(SolarPanel solarPanel);
 }

--- a/xolar/src/main/java/com/xodid/xolar/bill/service/BillService.java
+++ b/xolar/src/main/java/com/xodid/xolar/bill/service/BillService.java
@@ -1,0 +1,24 @@
+package com.xodid.xolar.bill.service;
+
+import com.xodid.xolar.bill.domain.Bill;
+import com.xodid.xolar.bill.repository.BillRepository;
+import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BillService {
+    private final BillRepository billRepository;
+
+    /* Transaction 함수들 */
+
+    // 해당 태양광패널의 모든 bill 리스트 조회
+    @Transactional(readOnly = true)
+    public List<Bill> findAllBySolarPanel(SolarPanel solarPanel){
+        return billRepository.findAllBySolarPanel(solarPanel);
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/electronic/domain/Electronic.java
+++ b/xolar/src/main/java/com/xodid/xolar/electronic/domain/Electronic.java
@@ -1,17 +1,19 @@
 package com.xodid.xolar.electronic.domain;
 
+import com.xodid.xolar.global.BaseTimeEntity;
 import com.xodid.xolar.solarpanel.domain.SolarPanel;
-import com.xodid.xolar.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
+@Getter
 @DynamicInsert // insert시 지정된 default값 적용
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Electronic {
+public class Electronic extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="elec_id",updatable = false)

--- a/xolar/src/main/java/com/xodid/xolar/electronic/repository/ElectronicRepository.java
+++ b/xolar/src/main/java/com/xodid/xolar/electronic/repository/ElectronicRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 
 @Repository
 public interface ElectronicRepository extends JpaRepository<Electronic, Long> {
+    // 특정 SolarPanel과 연관된 Electronic 엔티티 리스트 반환
     List<Electronic> findAllBySolarPanel(SolarPanel solarPanel);
 }

--- a/xolar/src/main/java/com/xodid/xolar/electronic/repository/ElectronicRepository.java
+++ b/xolar/src/main/java/com/xodid/xolar/electronic/repository/ElectronicRepository.java
@@ -1,0 +1,13 @@
+package com.xodid.xolar.electronic.repository;
+
+import com.xodid.xolar.electronic.domain.Electronic;
+import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ElectronicRepository extends JpaRepository<Electronic, Long> {
+    List<Electronic> findAllBySolarPanel(SolarPanel solarPanel);
+}

--- a/xolar/src/main/java/com/xodid/xolar/electronic/service/ElectronicService.java
+++ b/xolar/src/main/java/com/xodid/xolar/electronic/service/ElectronicService.java
@@ -1,0 +1,25 @@
+package com.xodid.xolar.electronic.service;
+
+import com.xodid.xolar.electronic.domain.Electronic;
+import com.xodid.xolar.electronic.repository.ElectronicRepository;
+import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ElectronicService {
+    private final ElectronicRepository electronicRepository;
+
+    /* Transaction 함수들 */
+
+    // solar-panel로 electronic 조회
+    @Transactional(readOnly = true)
+    public List<Electronic> findAllBySolarPanel(SolarPanel solarPanel) {
+        // 해당 태양광패널의 모든 electronic 리스트 조회
+        return electronicRepository.findAllBySolarPanel(solarPanel);
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/global/exception/ErrorCode.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     PANEL_NOT_FOUND(HttpStatus.NOT_FOUND, "PANEL-001","해당 태양광 패널을 찾을 수 없습니다."),
     ELECTRONIC_NOT_FOUND(HttpStatus.NOT_FOUND, "ELEC-001","해당 태양광 패널의 전력 정보를 찾을 수 없습니다."),
-    BILL_NOT_FOUNT(HttpStatus.NOT_FOUND, "BILL-001","해당 태양광 패널의 요금 정보를 찾을 수 없습니다.")
+    BILL_NOT_FOUNT(HttpStatus.NOT_FOUND, "BILL-001","해당 태양광 패널의 요금 정보를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"USER-001","해당 사용자를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus; //HttpStatus

--- a/xolar/src/main/java/com/xodid/xolar/global/exception/ErrorCode.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/exception/ErrorCode.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-001", "사용자를 찾을 수 없습니다.")
-
+    PANEL_NOT_FOUND(HttpStatus.NOT_FOUND, "PANEL-001","해당 태양광 패널을 찾을 수 없습니다."),
+    ELECTRONIC_NOT_FOUND(HttpStatus.NOT_FOUND, "ELEC-001","해당 태양광 패널의 전력 정보를 찾을 수 없습니다."),
+    BILL_NOT_FOUNT(HttpStatus.NOT_FOUND, "BILL-001","해당 태양광 패널의 요금 정보를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus; //HttpStatus

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/controller/SolarPanelController.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/controller/SolarPanelController.java
@@ -1,7 +1,6 @@
 package com.xodid.xolar.solarpanel.controller;
 
-import com.xodid.xolar.global.exception.CustomException;
-import com.xodid.xolar.global.exception.ErrorCode;
+import com.xodid.xolar.solarpanel.dto.SolarPanelListResponseDto;
 import com.xodid.xolar.solarpanel.dto.SolarPanelResponseDto;
 import com.xodid.xolar.solarpanel.service.SolarPanelService;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +10,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,5 +23,11 @@ public class SolarPanelController {
     @GetMapping("{panel_id}")
     public ResponseEntity<SolarPanelResponseDto> getSolarPanel(@PathVariable Long panel_id){
         return ResponseEntity.status(HttpStatus.OK).body(solarPanelService.findSolarPanelById(panel_id));
+    }
+
+    // 태양광 패널 목록 조회
+    @GetMapping
+    public ResponseEntity<List<SolarPanelListResponseDto>> getAllSolarPanels(){
+        return ResponseEntity.status(HttpStatus.OK).body(solarPanelService.findAllSolarPanels());
     }
 }

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/controller/SolarPanelController.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/controller/SolarPanelController.java
@@ -1,0 +1,25 @@
+package com.xodid.xolar.solarpanel.controller;
+
+import com.xodid.xolar.global.exception.CustomException;
+import com.xodid.xolar.global.exception.ErrorCode;
+import com.xodid.xolar.solarpanel.dto.SolarPanelResponseDto;
+import com.xodid.xolar.solarpanel.service.SolarPanelService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/solar-panels")
+public class SolarPanelController {
+    private final SolarPanelService solarPanelService;
+
+    @GetMapping("{panel_id}")
+    public ResponseEntity<SolarPanelResponseDto> getSolarPanel(@PathVariable Long panel_id){
+        return ResponseEntity.status(HttpStatus.OK).body(solarPanelService.findSolarPanelById(panel_id));
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/controller/SolarPanelController.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/controller/SolarPanelController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SolarPanelController {
     private final SolarPanelService solarPanelService;
 
+    // 태양광 패널 상세 조회
     @GetMapping("{panel_id}")
     public ResponseEntity<SolarPanelResponseDto> getSolarPanel(@PathVariable Long panel_id){
         return ResponseEntity.status(HttpStatus.OK).body(solarPanelService.findSolarPanelById(panel_id));

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/domain/SolarPanel.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/domain/SolarPanel.java
@@ -3,11 +3,13 @@ package com.xodid.xolar.solarpanel.domain;
 import com.xodid.xolar.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 public class SolarPanel {

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/dto/SolarPanelListResponseDto.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/dto/SolarPanelListResponseDto.java
@@ -1,0 +1,25 @@
+package com.xodid.xolar.solarpanel.dto;
+
+import com.xodid.xolar.electronic.domain.Electronic;
+import com.xodid.xolar.solarpanel.domain.OperationStatus;
+import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SolarPanelListResponseDto {
+    private Long panelId;
+    private String area;
+    private Integer elecGeneration;
+    private OperationStatus operationStatus;
+
+    public static SolarPanelListResponseDto from(SolarPanel solarPanel, Electronic electronic){
+        return new SolarPanelListResponseDto(
+                solarPanel.getPanelId(),
+                solarPanel.getArea(),
+                electronic.getElecGeneration(),
+                solarPanel.getOperationStatus()
+        );
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/dto/SolarPanelListResponseDto.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/dto/SolarPanelListResponseDto.java
@@ -1,6 +1,5 @@
 package com.xodid.xolar.solarpanel.dto;
 
-import com.xodid.xolar.electronic.domain.Electronic;
 import com.xodid.xolar.solarpanel.domain.OperationStatus;
 import com.xodid.xolar.solarpanel.domain.SolarPanel;
 import lombok.AllArgsConstructor;
@@ -14,11 +13,11 @@ public class SolarPanelListResponseDto {
     private Integer elecGeneration;
     private OperationStatus operationStatus;
 
-    public static SolarPanelListResponseDto from(SolarPanel solarPanel, Electronic electronic){
+    public static SolarPanelListResponseDto from(SolarPanel solarPanel, Integer todayElecGeneration){
         return new SolarPanelListResponseDto(
                 solarPanel.getPanelId(),
                 solarPanel.getArea(),
-                electronic.getElecGeneration(),
+                todayElecGeneration,
                 solarPanel.getOperationStatus()
         );
     }

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/dto/SolarPanelResponseDto.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/dto/SolarPanelResponseDto.java
@@ -1,0 +1,38 @@
+package com.xodid.xolar.solarpanel.dto;
+
+import com.xodid.xolar.bill.domain.Bill;
+import com.xodid.xolar.electronic.domain.Electronic;
+import com.xodid.xolar.solarpanel.domain.OperationStatus;
+import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SolarPanelResponseDto {
+    private Long panelId;
+    private String area;
+    private Integer imageNumber;
+    private OperationStatus operationStatus;
+    private Integer elecGeneration;
+    private Integer elecConsumption;
+    private Integer billGeneration;
+    private Integer billConsumption;
+
+    public static SolarPanelResponseDto from(SolarPanel solarPanel, Electronic electronic, Bill bill) {
+        return new SolarPanelResponseDto(
+                solarPanel.getPanelId(),
+                solarPanel.getArea(),
+                solarPanel.getImageNumber(),
+                solarPanel.getOperationStatus(),
+                electronic.getElecGeneration(),
+                electronic.getElecConsumption(),
+                bill.getBillGeneration(),
+                bill.getBillConsumption()
+        );
+
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/dto/SolarPanelResponseDto.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/dto/SolarPanelResponseDto.java
@@ -1,7 +1,5 @@
 package com.xodid.xolar.solarpanel.dto;
 
-import com.xodid.xolar.bill.domain.Bill;
-import com.xodid.xolar.electronic.domain.Electronic;
 import com.xodid.xolar.solarpanel.domain.OperationStatus;
 import com.xodid.xolar.solarpanel.domain.SolarPanel;
 import lombok.AccessLevel;
@@ -22,16 +20,16 @@ public class SolarPanelResponseDto {
     private Integer billGeneration;
     private Integer billConsumption;
 
-    public static SolarPanelResponseDto from(SolarPanel solarPanel, Electronic electronic, Bill bill) {
+    public static SolarPanelResponseDto from(SolarPanel solarPanel, int elecGeneration, int elecConsumption, int billGeneration, int billConsumption) {
         return new SolarPanelResponseDto(
                 solarPanel.getPanelId(),
                 solarPanel.getArea(),
                 solarPanel.getImageNumber(),
                 solarPanel.getOperationStatus(),
-                electronic.getElecGeneration(),
-                electronic.getElecConsumption(),
-                bill.getBillGeneration(),
-                bill.getBillConsumption()
+                elecGeneration,
+                elecConsumption,
+                billGeneration,
+                billConsumption
         );
 
     }

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/repository/SolarPanelRepository.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/repository/SolarPanelRepository.java
@@ -1,9 +1,13 @@
 package com.xodid.xolar.solarpanel.repository;
 
 import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import com.xodid.xolar.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SolarPanelRepository extends JpaRepository<SolarPanel, Long> {
+    List<SolarPanel> findAllByUser(User user);
 }

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/repository/SolarPanelRepository.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/repository/SolarPanelRepository.java
@@ -1,0 +1,9 @@
+package com.xodid.xolar.solarpanel.repository;
+
+import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SolarPanelRepository extends JpaRepository<SolarPanel, Long> {
+}

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/service/SolarPanelService.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/service/SolarPanelService.java
@@ -1,9 +1,9 @@
 package com.xodid.xolar.solarpanel.service;
 
 import com.xodid.xolar.bill.domain.Bill;
-import com.xodid.xolar.bill.repository.BillRepository;
+import com.xodid.xolar.bill.service.BillService;
 import com.xodid.xolar.electronic.domain.Electronic;
-import com.xodid.xolar.electronic.repository.ElectronicRepository;
+import com.xodid.xolar.electronic.service.ElectronicService;
 import com.xodid.xolar.global.exception.CustomException;
 import com.xodid.xolar.global.exception.ErrorCode;
 import com.xodid.xolar.solarpanel.domain.SolarPanel;
@@ -11,13 +11,13 @@ import com.xodid.xolar.solarpanel.dto.SolarPanelListResponseDto;
 import com.xodid.xolar.solarpanel.dto.SolarPanelResponseDto;
 import com.xodid.xolar.solarpanel.repository.SolarPanelRepository;
 import com.xodid.xolar.user.domain.User;
-import com.xodid.xolar.user.repository.UserRepository;
 import com.xodid.xolar.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,28 +25,90 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SolarPanelService {
     private final SolarPanelRepository solarPanelRepository;
-    private final ElectronicRepository electronicRepository;
-    private final BillRepository billRepository;
+    private final ElectronicService electronicService;
+    private final BillService billService;
     private final UserService userService;
 
     // panelId로 태양광 패널 상세 조회
     public SolarPanelResponseDto findSolarPanelById(Long panelId) {
         SolarPanel solarPanel = findById(panelId);
-        Electronic electronic = findElectronicBySolarPanel(solarPanel);
-        Bill bill = findBillBySolarPanel(solarPanel);
+        List<Electronic> elecList = electronicService.findAllBySolarPanel(solarPanel);
+        List<Bill> billList = billService.findAllBySolarPanel(solarPanel);
 
-        return SolarPanelResponseDto.from(solarPanel, electronic, bill);
+        // 현재 연도,월 가져오기
+        int year = LocalDateTime.now().getYear();
+        int month = LocalDateTime.now().getMonthValue();
+
+        // 이번달 전력 생산량 및 전력 소비량 총합
+        Integer elecGenerationSum =  elecGenerationSum(elecList, year, month);
+        Integer elecConsumption = elecConsumption(elecList, year, month);
+
+        // 이번달 예상 수입 및 전기요금 총합
+        Integer billGenerationSum = billGenerationSum(billList, year, month);
+        Integer billConsumption = billConsumption(billList, year, month);
+
+        return SolarPanelResponseDto.from(solarPanel, elecGenerationSum, elecConsumption, billGenerationSum, billConsumption);
     }
 
-    // 모든 태양광 패널 목록 조회
+    // 태양광 패널 목록 조회
     public List<SolarPanelListResponseDto> findAllSolarPanels(){
         User user = userService.findById(1L);
         List<SolarPanel> solarPanels = findAllSolarPanels(user);
 
+        // 오늘 날짜 가져오기
+        LocalDate today = LocalDate.now();
+
+        // 각 패널에 대한 전력 생산량과 상태 정보를 담은 DTO 생성
         return solarPanels.stream().map(solarPanel -> {
-            Electronic electronic = findElectronicBySolarPanel(solarPanel);
-            return SolarPanelListResponseDto.from(solarPanel, electronic);
+            List<Electronic> elecList = electronicService.findAllBySolarPanel(solarPanel);
+            Integer todayGeneration =  todayElecGeneration(elecList, today);
+            return SolarPanelListResponseDto.from(solarPanel, todayGeneration);
         }).collect(Collectors.toList());
+    }
+
+    // 각 패널에 대한 월별 전력 생산량 총합
+    public Integer elecGenerationSum(List<Electronic> elecList, int year, int month){
+        return elecList.stream()
+                .filter(electronic -> electronic.getDateTime().getYear() == year &&
+                        electronic.getDateTime().getMonthValue() == month)  // 이번 달에 해당하는 전력만 필터링
+                .mapToInt(Electronic::getElecGeneration)  // 전력 생산량 추출
+                .sum();
+    }
+
+    // 각 패널에 대한 월별 전력 소비량 총합
+    public Integer elecConsumption(List<Electronic> elecList, int year, int month){
+        return elecList.stream()
+                .filter(electronic -> electronic.getDateTime().getYear() == year &&
+                        electronic.getDateTime().getMonthValue() == month)  // 이번 달에 해당하는 전력만 필터링
+                .mapToInt(Electronic::getElecConsumption)  // 전력 소비량 추출
+                .sum();
+    }
+
+    // 각 패널에 대한 월별 예상 수입 총합
+    public Integer billGenerationSum(List<Bill> billList, int year, int month){
+        return billList.stream()
+                .filter(bill -> bill.getDateTime().getYear() == year &&
+                        bill.getDateTime().getMonthValue() == month)  // 이번 달에 해당하는 요금만 필터링
+                .mapToInt(Bill::getBillGeneration)  // 수입 추출
+                .sum();
+    }
+
+    // 각 패널에 대한 월별 예상 전기요금 총합
+    public Integer billConsumption(List<Bill> billList, int year, int month){
+        return billList.stream()
+                .filter(bill -> bill.getDateTime().getYear() == year &&
+                        bill.getDateTime().getMonthValue() == month)  // 이번 달에 해당하는 요금만 필터링
+                .mapToInt(Bill::getBillConsumption)  // 전기요금 추출
+                .sum();
+    }
+
+    // 각 패널에 대한 오늘 전력 생산량
+    public Integer todayElecGeneration(List<Electronic> elecList, LocalDate today){
+        return elecList.stream()
+                .filter(e -> e.getDateTime().toLocalDate().isEqual(today))
+                .map(Electronic::getElecGeneration)  // 전력 생산량 값만 추출
+                .findFirst()  // 첫 번째 값 찾기
+                .orElse(0);
     }
 
 
@@ -57,28 +119,6 @@ public class SolarPanelService {
     public SolarPanel findById(Long panelId) {
         return solarPanelRepository.findById(panelId).orElseThrow(
                 ()-> new CustomException(ErrorCode.PANEL_NOT_FOUND));
-    }
-
-    // solar-panel로 electronic 조회
-    @Transactional(readOnly = true)
-    public Electronic findElectronicBySolarPanel(SolarPanel solarPanel) {
-        // 해당 태양광패널의 모든 electronic 리스트 조회
-        List<Electronic> elecList  = electronicRepository.findAllBySolarPanel(solarPanel);
-
-        // 가장 최신 electronic 반환
-        return elecList.stream().max(Comparator.comparing(Electronic::getDateTime))
-                .orElseThrow(()-> new CustomException(ErrorCode.ELECTRONIC_NOT_FOUND));
-    }
-
-    // solar-panel로 bill 조회
-    @Transactional(readOnly = true)
-    public Bill findBillBySolarPanel(SolarPanel solarPanel){
-        // 해당 태양광패널의 모든 bill 리스트 조회
-        List<Bill> billList = billRepository.findAllBySolarPanel(solarPanel);
-
-        // 가장 최신 bill 반환
-        return billList.stream().max(Comparator.comparing(Bill::getDateTime))
-                .orElseThrow(()-> new CustomException(ErrorCode.BILL_NOT_FOUNT));
     }
 
     // user로 solar-panel 목록 조회

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/service/SolarPanelService.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/service/SolarPanelService.java
@@ -23,6 +23,7 @@ public class SolarPanelService {
     private final ElectronicRepository electronicRepository;
     private final BillRepository billRepository;
 
+    // panelId로 태양광 패널 상세 조회
     public SolarPanelResponseDto findSolarPanelById(Long panelId) {
         SolarPanel solarPanel = findById(panelId);
         Electronic electronic = findElectronicBySolarPanel(solarPanel);

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/service/SolarPanelService.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/service/SolarPanelService.java
@@ -1,0 +1,65 @@
+package com.xodid.xolar.solarpanel.service;
+
+import com.xodid.xolar.bill.domain.Bill;
+import com.xodid.xolar.bill.repository.BillRepository;
+import com.xodid.xolar.electronic.domain.Electronic;
+import com.xodid.xolar.electronic.repository.ElectronicRepository;
+import com.xodid.xolar.global.exception.CustomException;
+import com.xodid.xolar.global.exception.ErrorCode;
+import com.xodid.xolar.solarpanel.domain.SolarPanel;
+import com.xodid.xolar.solarpanel.dto.SolarPanelResponseDto;
+import com.xodid.xolar.solarpanel.repository.SolarPanelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SolarPanelService {
+    private final SolarPanelRepository solarPanelRepository;
+    private final ElectronicRepository electronicRepository;
+    private final BillRepository billRepository;
+
+    public SolarPanelResponseDto findSolarPanelById(Long panelId) {
+        SolarPanel solarPanel = findById(panelId);
+        Electronic electronic = findElectronicBySolarPanel(solarPanel);
+        Bill bill = findBillBySolarPanel(solarPanel);
+
+        return SolarPanelResponseDto.from(solarPanel, electronic, bill);
+    }
+
+
+    /* Transaction 함수들 */
+
+    // id로 solar-panel 조회
+    @Transactional(readOnly = true)
+    public SolarPanel findById(Long panelId) {
+        return solarPanelRepository.findById(panelId).orElseThrow(
+                ()-> new CustomException(ErrorCode.PANEL_NOT_FOUND));
+    }
+
+    // solar-panel로 electronic 조회
+    @Transactional(readOnly = true)
+    public Electronic findElectronicBySolarPanel(SolarPanel solarPanel) {
+        // 해당 태양광패널의 모든 electronic 리스트 조회
+        List<Electronic> elecList  = electronicRepository.findAllBySolarPanel(solarPanel);
+
+        // 가장 최신 electronic 반환
+        return elecList.stream().max(Comparator.comparing(Electronic::getDateTime))
+                .orElseThrow(()-> new CustomException(ErrorCode.ELECTRONIC_NOT_FOUND));
+    }
+
+    // solar-panel로 bill 조회
+    @Transactional(readOnly = true)
+    public Bill findBillBySolarPanel(SolarPanel solarPanel){
+        // 해당 태양광패널의 모든 bill 리스트 조회
+        List<Bill> billList = billRepository.findAllBySolarPanel(solarPanel);
+
+        // 가장 최신 bill 반환
+        return billList.stream().max(Comparator.comparing(Bill::getDateTime))
+                .orElseThrow(()-> new CustomException(ErrorCode.BILL_NOT_FOUNT));
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/user/repository/UserRepository.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.xodid.xolar.user.repository;
+
+import com.xodid.xolar.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/xolar/src/main/java/com/xodid/xolar/user/service/UserService.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/service/UserService.java
@@ -1,0 +1,24 @@
+package com.xodid.xolar.user.service;
+
+import com.xodid.xolar.global.exception.CustomException;
+import com.xodid.xolar.global.exception.ErrorCode;
+import com.xodid.xolar.user.domain.User;
+import com.xodid.xolar.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    /* Transaction 함수들 */
+
+    // id로 User 조회
+    @Transactional(readOnly = true)
+    public User findById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                ()-> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
# 구현 기능
- 태양광 패널 목록 조회
- 태양광 패널 상세 조회

# 구현 상태
- 태양광 패널 목록 조회: 전력 생산량은 오늘 생산한 전력을 반환하도록 구현함. 만약 오늘 생산한 전력이 없을시 0반환
![스크린샷 2024-10-13 233714](https://github.com/user-attachments/assets/b1084afd-ba7b-4611-a4b4-cca846215734)

- 태양광 패널 상세 조회: 전력 생산량, 소비량, 예상 수입, 전기요금은 이번달 총합을 계산하여 반환하도록 구현함.
![스크린샷 2024-10-13 233728](https://github.com/user-attachments/assets/14cff2ac-1937-4792-8d0b-a6e88fcb2a68)

# Resolve
- #1 
