### PR TITLE
[FEAT] OAuth2 로그인

### DIFF
--- a/xolar/build.gradle
+++ b/xolar/build.gradle
@@ -24,19 +24,33 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// spring
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// database
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// AWS IoT Core
 	implementation 'com.amazonaws:aws-java-sdk-iot:1.12.700'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt:0.12.6' //자바 JWT 라이브러리
+	implementation 'javax.xml.bind:jaxb-api:2.3.1' //XML 문서와 Java 객체 간 매핑 자동화
+
+	//oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/xolar/src/main/java/com/xodid/xolar/global/config/RedisConfig.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/config/RedisConfig.java
@@ -1,0 +1,55 @@
+package com.xodid.xolar.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    /**
+     * RedisConnectionFactory 빈 설정
+     *
+     * Redis와의 연결을 생성하고 관리함
+     * LettuceConnectionFactory를 사용하여 Redis 서버와 통신할 수 있도록 설정
+     *
+     * @return RedisConnectionFactory 객체
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        // Redis 서버의 host와 port 설정
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    /**
+     * RedisTemplate 빈 설정
+     *
+     * Redis에 데이터를 저장하고 조회하기 위한 RedisTemplate을 설정
+     * Redis에서 데이터를 읽고 쓸 때 키는 문자열 형식, 값은 JSON 형식으로 직렬화하여 저장
+     *
+     * @param redisConnectionFactory
+     * @return 설정된 RedisTemplate 객체
+     */
+    @Bean
+    public RedisTemplate<String , Object> redisTemplate(RedisConnectionFactory redisConnectionFactory){
+        RedisTemplate<String , Object> template = new RedisTemplate<>();
+        // Redis 연결 설정
+        template.setConnectionFactory(redisConnectionFactory);
+        // 키를 문자열 형식으로 직렬화
+        template.setKeySerializer(new StringRedisSerializer());
+        // 값을 JSON 형식으로 직렬화
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/global/exception/ErrorCode.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/exception/ErrorCode.java
@@ -10,7 +10,11 @@ public enum ErrorCode {
     PANEL_NOT_FOUND(HttpStatus.NOT_FOUND, "PANEL-001","해당 태양광 패널을 찾을 수 없습니다."),
     ELECTRONIC_NOT_FOUND(HttpStatus.NOT_FOUND, "ELEC-001","해당 태양광 패널의 전력 정보를 찾을 수 없습니다."),
     BILL_NOT_FOUNT(HttpStatus.NOT_FOUND, "BILL-001","해당 태양광 패널의 요금 정보를 찾을 수 없습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"USER-001","해당 사용자를 찾을 수 없습니다.")
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"USER-001","해당 사용자를 찾을 수 없습니다."),
+
+    // JWT 관련 에러 코드 추가
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "JWT-001", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT-002", "만료된 토큰입니다.")
     ;
 
     private final HttpStatus httpStatus; //HttpStatus

--- a/xolar/src/main/java/com/xodid/xolar/global/exception/ErrorCode.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/exception/ErrorCode.java
@@ -10,9 +10,12 @@ public enum ErrorCode {
     PANEL_NOT_FOUND(HttpStatus.NOT_FOUND, "PANEL-001","해당 태양광 패널을 찾을 수 없습니다."),
     ELECTRONIC_NOT_FOUND(HttpStatus.NOT_FOUND, "ELEC-001","해당 태양광 패널의 전력 정보를 찾을 수 없습니다."),
     BILL_NOT_FOUNT(HttpStatus.NOT_FOUND, "BILL-001","해당 태양광 패널의 요금 정보를 찾을 수 없습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"USER-001","해당 사용자를 찾을 수 없습니다."),
 
-    // JWT 관련 에러 코드 추가
+    // User 관련 에러 코드
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"USER-001","해당 사용자를 찾을 수 없습니다."),
+    USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER-002","해당 이메일의 유저가 존재하지 않습니다."),
+
+    // JWT 관련 에러 코드
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "JWT-001", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT-002", "만료된 토큰입니다.")
     ;

--- a/xolar/src/main/java/com/xodid/xolar/global/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,55 @@
+package com.xodid.xolar.global.handler;
+
+import com.xodid.xolar.global.jwt.TokenProvider;
+import com.xodid.xolar.user.domain.User;
+import com.xodid.xolar.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        // OAuth2 인증된 사용자 정보 가져오기
+        DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+
+        // 사용자 속성에서 이메일 추출
+        String email = (String) oAuth2User.getAttributes().get("email");
+
+        // email을 통해 데이터베이스에서 User 엔티티 조회
+        Optional<User> userOptional = userRepository.findByEmail(email);
+        User user = userOptional.orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        // AccessToken, RefreshToken 발급
+        String accessToken = tokenProvider.createAccessToken(user);
+        String refreshToken = tokenProvider.createRefreshToken(user);
+
+        // 리프레시토큰 저장
+        tokenProvider.saveRefreshToken(user.getUserId(), refreshToken);
+
+        // JSON형식 응답 설정
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // AccessToken, RefreshToken 토큰 전달
+        String jsonResponse = String.format("{\"accessToken\":\"%s\", \"refreshToken\":\"%s\"}", accessToken, refreshToken);
+        response.getWriter().write(jsonResponse);
+        response.getWriter().flush();
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/global/jwt/JwtAuthenticationFilter.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,86 @@
+package com.xodid.xolar.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xodid.xolar.global.exception.CustomException;
+import com.xodid.xolar.global.exception.ErrorDto;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+
+    private static final String BEARER = "Bearer ";
+    private static final String HEADER = "Authorization";
+
+    /**
+     * JWT 인증 필터
+     *
+     * HTTP 요청을 가로채 JWT 토큰을 검사하고, 유효한 경우 인증 정보를 설정한다.
+     * 토큰이 유효하지 않을 경우, CustomException을 던져 에러 응답을 반환한다.
+     *
+     * @param request HTTP 요청 객체
+     * @param response HTTP 요청 객체
+     * @param filterChain 필터 체인 객체
+     * @throws ServletException 서블릿 예외 발생 시
+     * @throws IOException 입출력 예외 발생 시
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // 요청 헤더의 Authorization 키 값 조회
+        String authorizationHeader = request.getHeader(HEADER);
+
+        // Bearer 접두사를 제거하여 토큰 추출
+        String token = getAccessToken(authorizationHeader);
+
+        try{
+            // 토큰이 유효한지 확인하고, 유효하다면 인증정보 설정
+            if(!ObjectUtils.isEmpty(token) && tokenProvider.isValidToken(token)){
+                Authentication authentication = tokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (CustomException e){
+            // CustomException이 발생하면 에러 응답을 설정하여 클라이언트에 전송
+            ErrorDto errorResponse = ErrorDto.builder()
+                    .status(e.getErrorCode().getHttpStatus().value())
+                    .code(e.getErrorCode().getCode())
+                    .msg(e.getErrorCode().getMessage())
+                    .build();
+
+            // 응답의 상태 코드와 Content-Type 및 인코딩 설정
+            response.setStatus(e.getErrorCode().getHttpStatus().value());
+            response.setContentType("application/json; charset=UTF-8"); // UTF-8 인코딩 설정
+            response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+            return;
+        }
+
+        // 다음 필터로 요청과 응답 전달
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 접두사를 제거해 토큰 추출
+     *
+     * @param authorizationHeader Authorization 헤더 값
+     * @return Bearer 접두사를 제외한 JWT 토큰 또는 null (유효하지 않은 경우)
+     */
+    private String getAccessToken(String authorizationHeader){
+        // Token이 null이 아니고 Bearer로 시작해야지 정상적인 Token
+        if(authorizationHeader != null && authorizationHeader.startsWith(BEARER)){
+            // 정상적인 토큰이라면 앞에 Bearer 제거 후 리턴
+            return authorizationHeader.substring(BEARER.length());
+        }
+        return null;
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/global/jwt/TokenProvider.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/jwt/TokenProvider.java
@@ -1,0 +1,183 @@
+package com.xodid.xolar.global.jwt;
+
+import com.xodid.xolar.global.exception.CustomException;
+import com.xodid.xolar.global.exception.ErrorCode;
+import com.xodid.xolar.user.domain.User;
+import com.xodid.xolar.user.repository.UserRepository;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    // application.yml에 저장한 jwt값 가져오기
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    // 토큰 만료시간 설정
+    private static Long accessTokenExpiration = 1000*30L; // 1시간 = 1000(ms->s) * 60(s->m) * 60(m->h)
+    private static Long refreshTokenExpiration = 1000*60*60*25*14L; // 2주 = 1000(ms->s) * 60(s->m) * 60(m->h) * 24(h->하루) * 14(2주)
+
+    // 토큰에 포함할 기본 정보와 클레임 키값 설정
+    private static final String AUTH_CLAIM = "auth";
+
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * AccessToken 생성 메소드
+     * 사용자의 이메일과 권한 정보를 포함해 AccessToken을 생성
+     *
+     * @param user 토큰에 포함할 사용자 정보
+     * @return 생성된 액세스 토큰
+     */
+    public String createAccessToken(User user){
+        Date now = new Date();
+        return Jwts.builder()
+                // 헤더 - 토큰 타입: JWT
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                // 내용 - 토큰 발급자
+                .setIssuer(issuer)
+                // 내용 - 토큰이 발급된 시간: 현재 시간
+                .setIssuedAt(now)
+                // 내용 - 토큰 만료 시간: expiredMs 변수값
+                .setExpiration(new Date(now.getTime() + accessTokenExpiration))
+                // 내용 - 토큰 제목: 사용자 이메일
+                .setSubject(user.getEmail())
+                // 서명 - 시크릿키와 함께 해시값을 HS256 방식으로 암호화
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    /**
+     * RefreshToken 생성 메소드
+     * RefreshToken에는 권한이 필요하지 않으므로 제외
+     *
+     * @return 생성된 리프레시 토큰
+     */
+    public String createRefreshToken(User user){
+        Date now = new Date();
+        return Jwts.builder()
+                // 헤더 - 토큰 타입: JWT
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                // 내용 - 토큰 발급자
+                .setIssuer(issuer)
+                // 내용 - 토큰이 발급된 시간: 현재 시간
+                .setIssuedAt(now)
+                // 내용 - 토큰 만료 시간: expiredMs 변수값
+                .setExpiration(new Date(now.getTime() + refreshTokenExpiration))
+                // 내용 - 토큰 제목: 사용자 이메일
+                .setSubject(user.getEmail())
+                // 서명 - 시크릿키와 함께 해시값을 HS256 방식으로 암호화
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    /**
+     * Redis에 리프레시 토큰을 저장하는 메소드
+     * key: 사용자 ID, alue: 리프레시 토큰
+     * 리프레시토큰 만료 시간(refreshTokenExpiration)을 만료시간으로 정해 자동으로 삭제되도록 설정
+     *
+     * @param userId 저장할 사용자 Id (Redis 키로 사용)
+     * @param refreshToken 저장할 리프레시 토큰
+     */
+    public void saveRefreshToken(Long userId, String refreshToken){
+        redisTemplate.opsForValue().set(userId.toString(),refreshToken, Duration.ofMillis(refreshTokenExpiration));
+    }
+
+    /**
+     * AccessToken에서 email 추출
+     * 토큰이 유효한지 확인 후 이메일 클레임 값을 추출
+     *
+     * @param accessToken 이메일을 추출할 액세스 토큰
+     * @return 추출된 이메일 또는 null (유효하지 않은 경우)
+     */
+    public String extractEmail(String accessToken){
+        if(isValidToken(accessToken)){
+            return getClaims(accessToken).getSubject();
+        }
+        return null;
+    }
+
+    /**
+     * 유효한 토큰인지 검증
+     * 유효하지 않은 경우 CustomException을 발생시킴
+     *
+     * @param token 검증할 토큰
+     * @return 유효성
+     */
+    public boolean isValidToken(String token){
+        try{
+            // secretKey를 사용해 토큰 복호화
+            Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            log.info("Validate token success");
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT token", e);
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token", e);
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token", e);
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty", e);
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    /**
+     * 토큰에서 사용자 인증 정보를 꺼내 반환
+     * JWT 토큰의 클레임에서 사용자 이메일과 권한 정보를 추출하여 Authentication 객체를 생성
+     *
+     * @param token 인증 정보를 추출할 토큰
+     * @return 생성된 Authentication 객체
+     */
+    public Authentication getAuthentication(String token){
+        // 토큰 복호화
+        Claims claims = getClaims(token);
+
+        // 토큰에서 정보를 꺼냄
+        Set<SimpleGrantedAuthority> authorities = Collections
+                .singleton(new SimpleGrantedAuthority("ROLE_"+claims.get(AUTH_CLAIM)));
+
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails
+                .User(claims.getSubject(), "", authorities), token, authorities);
+    }
+
+    /**
+     * 토큰을 복호화한 후 페이로드 반환
+     *
+     * @param token 복호화할 토큰
+     * @return 토큰의 페이로드
+     */
+    private Claims getClaims(String token){
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getPayload();
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/global/jwt/TokenProvider.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/jwt/TokenProvider.java
@@ -33,7 +33,7 @@ public class TokenProvider {
     private String issuer;
 
     // 토큰 만료시간 설정
-    private static Long accessTokenExpiration = 1000*30L; // 1시간 = 1000(ms->s) * 60(s->m) * 60(m->h)
+    private static Long accessTokenExpiration = 1000*60*60L; // 1시간 = 1000(ms->s) * 60(s->m) * 60(m->h)
     private static Long refreshTokenExpiration = 1000*60*60*25*14L; // 2주 = 1000(ms->s) * 60(s->m) * 60(m->h) * 24(h->하루) * 14(2주)
 
     // 토큰에 포함할 기본 정보와 클레임 키값 설정

--- a/xolar/src/main/java/com/xodid/xolar/global/utils/SecurityUtils.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/utils/SecurityUtils.java
@@ -1,0 +1,22 @@
+package com.xodid.xolar.global.utils;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+    /**
+     * 현재 인증된 사용자 email 반환 메서드
+     * 만약 인증 정보가 없는 경우, null 반환
+     */
+    public static String getCurrentUserEmail() {
+        // SecurityContext에서 현재 인증 정보를 가져옴
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증정보가 없거나 사용자 이메일이 없는 경우, null 반환
+        if (authentication == null || authentication.getName() == null) {
+            return null;
+        }
+        return authentication.getName();
+    }
+}
+}

--- a/xolar/src/main/java/com/xodid/xolar/global/utils/SecurityUtils.java
+++ b/xolar/src/main/java/com/xodid/xolar/global/utils/SecurityUtils.java
@@ -19,4 +19,3 @@ public class SecurityUtils {
         return authentication.getName();
     }
 }
-}

--- a/xolar/src/main/java/com/xodid/xolar/solarpanel/service/SolarPanelService.java
+++ b/xolar/src/main/java/com/xodid/xolar/solarpanel/service/SolarPanelService.java
@@ -8,6 +8,7 @@ import com.xodid.xolar.electronic.service.ElectronicService;
 import com.xodid.xolar.global.config.AwsConfig;
 import com.xodid.xolar.global.exception.CustomException;
 import com.xodid.xolar.global.exception.ErrorCode;
+import com.xodid.xolar.global.utils.SecurityUtils;
 import com.xodid.xolar.solarpanel.domain.SolarPanel;
 import com.xodid.xolar.solarpanel.dto.SolarPanelListResponseDto;
 import com.xodid.xolar.solarpanel.dto.SolarPanelRequestDto;
@@ -20,6 +21,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.Security;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -64,7 +66,7 @@ public class SolarPanelService {
      * 태양광 패널 목록을 조회하는 메서드
      */
     public List<SolarPanelListResponseDto> findAllSolarPanels(){
-        User user = userService.findById(1L);
+        User user = userService.findByEmail(SecurityUtils.getCurrentUserEmail());
         List<SolarPanel> solarPanels = findAllSolarPanels(user);
 
         // 오늘 날짜 가져오기
@@ -137,7 +139,7 @@ public class SolarPanelService {
         // 해당 코드의 태양광패널이 DB에 이미 존재하는지 확인
         if(!isPanelCodeExist(requestDto.getPanelCode())){
             // 태양광 패널이 존재하지 않는 경우, 새로운 태양광패널 DB에 저장 및 AWS IoT 사물에 등록
-            User user = userService.findById(1L);
+            User user = userService.findByEmail(SecurityUtils.getCurrentUserEmail());
             SolarPanel solarPanel = requestDto.toEntity(user);
             SolarPanel createdPanel = solarPanelRepository.save(solarPanel);
             return createThingAutomatically(requestDto.getPanelCode());

--- a/xolar/src/main/java/com/xodid/xolar/user/controller/UserController.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.xodid.xolar.user.controller;
+
+import com.xodid.xolar.user.dto.TokenRequestDto;
+import com.xodid.xolar.user.dto.TokenResponseDto;
+import com.xodid.xolar.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequestMapping("auth")
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    /**
+     * 액세스토큰 재발급 처리 메서드
+     */
+    @PostMapping("/token")
+    public ResponseEntity<TokenResponseDto> reissuedAccessToken(@RequestBody TokenRequestDto requestDto){
+        return ResponseEntity.status(HttpStatus.OK).body(userService.reissueAccessToken(requestDto.getRefreshToken()));
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/user/controller/UserController.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/controller/UserController.java
@@ -6,10 +6,7 @@ import com.xodid.xolar.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RequestMapping("auth")

--- a/xolar/src/main/java/com/xodid/xolar/user/domain/SocialType.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/domain/SocialType.java
@@ -1,0 +1,5 @@
+package com.xodid.xolar.user.domain;
+
+public enum SocialType {
+    GOOGLE, KAKAO
+}

--- a/xolar/src/main/java/com/xodid/xolar/user/domain/User.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/domain/User.java
@@ -2,8 +2,11 @@ package com.xodid.xolar.user.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
@@ -17,4 +20,17 @@ public class User {
 
     @Column(nullable = false)
     private String email;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    private String socialId;
+
+    @Builder
+    public User(String name, String email, SocialType socialType, String socialId) {
+        this.name = name;
+        this.email = email;
+        this.socialType = socialType;
+        this.socialId = socialId;
+    }
 }

--- a/xolar/src/main/java/com/xodid/xolar/user/dto/TokenRequestDto.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/dto/TokenRequestDto.java
@@ -1,0 +1,11 @@
+package com.xodid.xolar.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRequestDto {
+    private String refreshToken;
+}
+

--- a/xolar/src/main/java/com/xodid/xolar/user/dto/TokenResponseDto.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/dto/TokenResponseDto.java
@@ -1,0 +1,17 @@
+package com.xodid.xolar.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenResponseDto {
+    private String accessToken;
+
+    @Builder
+    public TokenResponseDto(final String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/user/oauth/GoogleOAuth2UserInfo.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/oauth/GoogleOAuth2UserInfo.java
@@ -1,0 +1,29 @@
+package com.xodid.xolar.user.oauth;
+
+import java.util.Map;
+
+/**
+ * 구글에서 제공하는 사용자 정보를 다룸
+ * OAuth2UserInfo를 확장해 구글의 사용자 정보 구조에 맞춰 구현
+ */
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/user/oauth/KakaoOAuth2UserInfo.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/oauth/KakaoOAuth2UserInfo.java
@@ -1,0 +1,31 @@
+package com.xodid.xolar.user.oauth;
+
+import java.util.Map;
+
+/**
+ * 카카오에서 제공하는 사용자 정보를 다룸
+ * OAuth2UserInfo를 확장해 카카오의 사용자 정보 구조에 맞춰 구현
+ */
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return (String) properties.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return (String) kakaoAccount.get("email");
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/user/oauth/OAuth2UserInfo.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/oauth/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package com.xodid.xolar.user.oauth;
+
+import java.util.Map;
+
+/**
+ * 소셜 로그인에서 공통적으로 사용하는 사용자 정보 추상 클래스
+ *
+ * 공통적으로 필요한 메서드(ID, 닉네임, 이메일)을 가져오는 메서드를 정의하고 있으며,
+ * 소셜 로그인별로 다르게 구현할 수 있도록 추상 메서드로 선언
+ */
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    // 소셜 로그인별로(구글, 카카오) 서로 다른 방식으로 사용자 정보를 제공하므로 추상 클래스 메서드로 선언
+    public abstract String getId();
+    public abstract String getName();
+    public abstract String getEmail();
+}
+

--- a/xolar/src/main/java/com/xodid/xolar/user/repository/UserRepository.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/repository/UserRepository.java
@@ -4,6 +4,9 @@ import com.xodid.xolar.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }

--- a/xolar/src/main/java/com/xodid/xolar/user/service/CustomOAuth2UserService.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,88 @@
+package com.xodid.xolar.user.service;
+
+import com.xodid.xolar.user.domain.SocialType;
+import com.xodid.xolar.user.domain.User;
+import com.xodid.xolar.user.oauth.GoogleOAuth2UserInfo;
+import com.xodid.xolar.user.oauth.KakaoOAuth2UserInfo;
+import com.xodid.xolar.user.oauth.OAuth2UserInfo;
+import com.xodid.xolar.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    /**
+     * OAuth2UserRequest를 받아 사용자를 로드하는 메서드
+     *
+     * @param userRequest OAuth2UserRequest 객체로, OAuth2 클라이언트 정보가 담겨 있음
+     * @return OAuth2User 인증된 사용자 정보 객체
+     * @throws OAuth2AuthenticationException OAuth 인증 실패 시 예외 발생
+     */
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // OAuth2 사용자 정보 로드
+        OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+        // OAuth2 제공자(Google, Kakao)의 ID를 통해 SocialType 결정
+        SocialType socialType = SocialType.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+        OAuth2UserInfo oAuth2UserInfo;
+
+        // 소셜 로그인 타입에 따라 OAuth2UserInfo 객체 생성
+        if (socialType == SocialType.GOOGLE) {
+            oAuth2UserInfo = new GoogleOAuth2UserInfo(oAuth2User.getAttributes());
+        } else if (socialType == SocialType.KAKAO) {
+            oAuth2UserInfo = new KakaoOAuth2UserInfo(oAuth2User.getAttributes());
+        } else {
+            throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다.");
+        }
+
+        // DB에서 해당 사용자 조회 -> 없으면 새로 생성
+        User user = userRepository.findByEmail(oAuth2UserInfo.getEmail())
+                .orElseGet(() -> createUser(oAuth2UserInfo, socialType));
+
+        // 사용자 속성 생성
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+        attributes.put("id", user.getUserId());
+        attributes.put("email", user.getEmail());
+
+        // DefaultOAuth2User 객체 생성하여 반환
+        return new DefaultOAuth2User(
+                Collections.singleton(new OAuth2UserAuthority(attributes)),
+                attributes,
+                "email"); // 기본 식별자 지정
+    }
+
+    /**
+     * 사용자 생성 메서드
+     *
+     * @param oAuth2UserInfo
+     * @param socialType
+     * @return
+     */
+    private User createUser(OAuth2UserInfo oAuth2UserInfo, SocialType socialType) {
+        User user = User.builder()
+                .email(oAuth2UserInfo.getEmail())
+                .name(oAuth2UserInfo.getName())
+                .socialId(oAuth2UserInfo.getId())
+                .socialType(socialType)
+                .build();
+        return userRepository.save(user);
+    }
+}

--- a/xolar/src/main/java/com/xodid/xolar/user/service/UserService.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/service/UserService.java
@@ -56,6 +56,14 @@ public class UserService {
                 ()-> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
+    // email로 User 조회
+    @Transactional(readOnly = true)
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(
+                ()-> new CustomException(ErrorCode.USER_NOT_EXIST)
+        );
+    }
+
     // Email로 사용자 객체 가져오기
     @Transactional(readOnly = true)
     public User getUserByEmail(String email){

--- a/xolar/src/main/java/com/xodid/xolar/user/service/UserService.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/service/UserService.java
@@ -2,9 +2,12 @@ package com.xodid.xolar.user.service;
 
 import com.xodid.xolar.global.exception.CustomException;
 import com.xodid.xolar.global.exception.ErrorCode;
+import com.xodid.xolar.global.jwt.TokenProvider;
 import com.xodid.xolar.user.domain.User;
+import com.xodid.xolar.user.dto.TokenResponseDto;
 import com.xodid.xolar.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +15,37 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * AccessToken 재발급
+     *
+     * 클라이언트가 전달한 리프레시 토큰을 검증해 유효한 경우 새로운 액세스토큰을 발급한다.
+     *
+     * @param refreshToken 클라이언트에서 전달된 리프레시 토큰
+     * @return 새로운 AccessToken을 포함한 TokenResponseDto 객체
+     */
+    public TokenResponseDto reissueAccessToken(String refreshToken){
+        // 전달받은 리프레시 토큰에서 이메일을 추출하여 사용자 정보 가져오기
+        String email = tokenProvider.extractEmail(refreshToken);
+        User user = getUserByEmail(email);
+
+        // Redis에서 해당 사용자 Id를 키로 하는 리프래시 토큰 가져오기
+        String storedRefreshToken = redisTemplate.opsForValue().get(user.getUserId().toString());
+
+        // 전달받은 리프레시 토큰과 Redis에 저장된 리프레시 토큰이 일치하는지 확인
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)){
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // 일치한다면 새로운 AccessToken 생성
+        String accessToken = tokenProvider.createAccessToken(user);
+
+        return TokenResponseDto.builder()
+                .accessToken(accessToken)
+                .build();
+    }
 
     /* Transaction 함수들 */
 
@@ -20,5 +54,11 @@ public class UserService {
     public User findById(Long userId) {
         return userRepository.findById(userId).orElseThrow(
                 ()-> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // Email로 사용자 객체 가져오기
+    @Transactional(readOnly = true)
+    public User getUserByEmail(String email){
+        return userRepository.findByEmail(email).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_EXIST));
     }
 }

--- a/xolar/src/main/java/com/xodid/xolar/user/service/UserService.java
+++ b/xolar/src/main/java/com/xodid/xolar/user/service/UserService.java
@@ -49,13 +49,6 @@ public class UserService {
 
     /* Transaction 함수들 */
 
-    // id로 User 조회
-    @Transactional(readOnly = true)
-    public User findById(Long userId) {
-        return userRepository.findById(userId).orElseThrow(
-                ()-> new CustomException(ErrorCode.USER_NOT_FOUND));
-    }
-
     // email로 User 조회
     @Transactional(readOnly = true)
     public User findByEmail(String email) {


### PR DESCRIPTION
# 구현 기능
- OAuth2 구글, 카카오 로그인
- RefreshToken을 사용한 AccessToken 재발급

# 구현 상태
- 구글 로그인
![스크린샷 2024-12-25 010316](https://github.com/user-attachments/assets/911d10d2-90d0-4f19-9d1c-82cf632ef163)
![스크린샷 2024-12-25 010352](https://github.com/user-attachments/assets/5bbc6200-1a1f-4261-870b-8a434e1b5b7b)
![스크린샷 2024-12-25 010404](https://github.com/user-attachments/assets/d1b8ee94-be6c-49ee-a18e-02af77543f71)

- 카카오 로그인
![스크린샷 2024-12-25 011153](https://github.com/user-attachments/assets/fd500496-40cc-4dcc-907a-ae8719952ea3)
![스크린샷 2024-12-25 011443](https://github.com/user-attachments/assets/933a148c-1429-4e19-b4d3-5b7d652f9b48)
![스크린샷 2024-12-25 011452](https://github.com/user-attachments/assets/9d675ae3-91f2-4872-b96a-a3bc8514593e)



- 액세스토큰을 사용해 로그인한 사용자의 태양광 패널 목록 조회
![스크린샷 2024-12-25 010530](https://github.com/user-attachments/assets/38513616-bbbe-4dbe-82b5-838ae7f9d2eb)

- 만료된 토큰일 시
![스크린샷 2024-12-25 010711](https://github.com/user-attachments/assets/d25c315b-417e-4fc1-be06-53619429472a)

- 유효하지 않은 토큰일 시
![스크린샷 2024-12-25 010546](https://github.com/user-attachments/assets/b3e0a86d-df41-4909-ab1d-70bacb420542)

- 액세스토큰 재발급
![스크린샷 2024-12-25 010441](https://github.com/user-attachments/assets/968f22ad-1486-4d95-b7cb-7b1163f38648)

# Resolve
- #14 
